### PR TITLE
Make link breadcrumbs lighter

### DIFF
--- a/style.css
+++ b/style.css
@@ -559,6 +559,10 @@ a.LwS2ce:link {
     color: #999 !important;
 }
 
+.rpCHfe {
+    color: #52565a;
+}
+
 .JolIg, .C9iYEe, .gb_3a .gb_0 {
     color: white !important;
 }


### PR DESCRIPTION
For some reason, when I search I don't get the links back, instead Google gives me some breadcrumbs that I can't see against the black background. The selector I added is for those breadcrumbs, and it doesn't seem to affect the link text. Tested on Chrome 77.0.3865.90

Just so you can see what I am talking about, here is what a search result looks like without the change:
<img width="618" alt="Screen Shot 2019-10-14 at 10 43 00 AM" src="https://user-images.githubusercontent.com/41386393/66771590-8e700f80-ee6f-11e9-826b-2836170e39d5.png">

After:
<img width="612" alt="Screen Shot 2019-10-14 at 10 43 18 AM" src="https://user-images.githubusercontent.com/41386393/66771604-96c84a80-ee6f-11e9-811f-f7c4ee4a638b.png">
